### PR TITLE
Integration with commcare

### DIFF
--- a/Pdf417MobiDemo/pdf417MobiDemo/src/main/AndroidManifest.xml
+++ b/Pdf417MobiDemo/pdf417MobiDemo/src/main/AndroidManifest.xml
@@ -24,6 +24,11 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="com.google.zxing.client.android.SCAN"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+            </intent-filter>
+
         </activity>
         <activity
             android:name="com.microblink.activity.Pdf417ScanActivity"

--- a/Pdf417MobiDemo/pdf417MobiDemo/src/main/java/mobi/pdf417/demo/Pdf417MobiDemo.java
+++ b/Pdf417MobiDemo/pdf417MobiDemo/src/main/java/mobi/pdf417/demo/Pdf417MobiDemo.java
@@ -290,12 +290,6 @@ public class Pdf417MobiDemo extends Activity {
             }
 
             Intent dataToReturn = new Intent();
-
-            //this is how you would add responses to the default bundle.
-            //Bundle responses = new Bundle();
-            //responses.putString("example_id", "Example text");
-            //dataToReturn.putExtra("odk_intent_bundle", responses);
-
             // this is the value that CommCare will use as the result of the intent question
             dataToReturn.putExtra("SCAN_RESULT", barcodeData);
             setResult(Activity.RESULT_OK, dataToReturn);

--- a/Pdf417MobiDemo/pdf417MobiDemo/src/main/java/mobi/pdf417/demo/Pdf417MobiDemo.java
+++ b/Pdf417MobiDemo/pdf417MobiDemo/src/main/java/mobi/pdf417/demo/Pdf417MobiDemo.java
@@ -45,6 +45,7 @@ public class Pdf417MobiDemo extends Activity {
         setContentView(R.layout.activity_main);
         TextView tvVersion = (TextView) findViewById(R.id.tvVersion);
         tvVersion.setText(buildVersionString());
+        startStuff();
     }
 
     /**
@@ -72,7 +73,7 @@ public class Pdf417MobiDemo extends Activity {
         }
     }
 
-    public void btnScan_click(View v) {
+    public void startStuff() {
         Log.i(TAG, "scan will be performed");
         // Intent for ScanActivity
         Intent intent = new Intent(this, Pdf417ScanActivity.class);
@@ -120,7 +121,7 @@ public class Pdf417MobiDemo extends Activity {
         oneDimensionalRecognizerSettings.setScanCode128(true);
         // set this to true to use heavier algorithms for scanning 1D barcodes
         // those algorithms are slower, but can scan lower resolution barcodes
-//        oneDimensionalRecognizerSettings.setTryHarder(true);
+        oneDimensionalRecognizerSettings.setTryHarder(true);
 
         // ZXingRecognizerSettings define settings for scanning barcodes with ZXing library
         // We use modified version of ZXing library to support scanning of barcodes for which
@@ -154,7 +155,7 @@ public class Pdf417MobiDemo extends Activity {
 
         // if you do not want the dialog to be shown when scanning completes, add following extra
         // to intent
-//        intent.putExtra(Pdf417ScanActivity.EXTRAS_SHOW_DIALOG_AFTER_SCAN, false);
+        intent.putExtra(Pdf417ScanActivity.EXTRAS_SHOW_DIALOG_AFTER_SCAN, false);
 
         // if you want to enable pinch to zoom gesture, add following extra to intent
         intent.putExtra(Pdf417ScanActivity.EXTRAS_ALLOW_PINCH_TO_ZOOM, true);
@@ -215,12 +216,13 @@ public class Pdf417MobiDemo extends Activity {
             // available.
 
             StringBuilder sb = new StringBuilder();
+            String barcodeData = "";
 
             for(BaseRecognitionResult res : resultArray) {
                 if(res instanceof Pdf417ScanResult) { // check if scan result is result of Pdf417 recognizer
                     Pdf417ScanResult result = (Pdf417ScanResult) res;
                     // getStringData getter will return the string version of barcode contents
-                    String barcodeData = result.getStringData();
+                    barcodeData = result.getStringData();
                     // isUncertain getter will tell you if scanned barcode contains some uncertainties
                     boolean uncertainData = result.isUncertain();
                     // getRawData getter will return the raw data information object of barcode contents
@@ -261,7 +263,7 @@ public class Pdf417MobiDemo extends Activity {
                     // with getBarcodeType you can obtain barcode type enum that tells you the type of decoded barcode
                     BarcodeType type = result.getBarcodeType();
                     // as with PDF417, getStringData will return the string contents of barcode
-                    String barcodeData = result.getStringData();
+                    barcodeData = result.getStringData();
                     if(checkIfDataIsUrlAndCreateIntent(barcodeData)) {
                         return;
                     } else {
@@ -275,7 +277,7 @@ public class Pdf417MobiDemo extends Activity {
                     // with getBarcodeType you can obtain barcode type enum that tells you the type of decoded barcode
                     BarcodeType type = result.getBarcodeType();
                     // as with PDF417, getStringData will return the string contents of barcode
-                    String barcodeData = result.getStringData();
+                    barcodeData = result.getStringData();
                     if(checkIfDataIsUrlAndCreateIntent(barcodeData)) {
                         return;
                     } else {
@@ -287,10 +289,17 @@ public class Pdf417MobiDemo extends Activity {
                 }
             }
 
-            Intent intent = new Intent(Intent.ACTION_SEND);
-            intent.setType("text/plain");
-            intent.putExtra(Intent.EXTRA_TEXT, sb.toString());
-            startActivity(Intent.createChooser(intent, getString(R.string.UseWith)));
+            Intent dataToReturn = new Intent();
+
+            //this is how you would add responses to the default bundle.
+            //Bundle responses = new Bundle();
+            //responses.putString("example_id", "Example text");
+            //dataToReturn.putExtra("odk_intent_bundle", responses);
+
+            // this is the value that CommCare will use as the result of the intent question
+            dataToReturn.putExtra("SCAN_RESULT", barcodeData);
+            setResult(Activity.RESULT_OK, dataToReturn);
+            finish();
         }
     }
 }

--- a/Pdf417MobiDemo/pdf417MobiDemo/src/main/java/mobi/pdf417/demo/Pdf417MobiDemo.java
+++ b/Pdf417MobiDemo/pdf417MobiDemo/src/main/java/mobi/pdf417/demo/Pdf417MobiDemo.java
@@ -45,7 +45,7 @@ public class Pdf417MobiDemo extends Activity {
         setContentView(R.layout.activity_main);
         TextView tvVersion = (TextView) findViewById(R.id.tvVersion);
         tvVersion.setText(buildVersionString());
-        startStuff();
+        startScanning();
     }
 
     /**
@@ -73,7 +73,7 @@ public class Pdf417MobiDemo extends Activity {
         }
     }
 
-    public void startStuff() {
+    public void startScanning() {
         Log.i(TAG, "scan will be performed");
         // Intent for ScanActivity
         Intent intent = new Intent(this, Pdf417ScanActivity.class);

--- a/Pdf417MobiDemo/pdf417MobiDemo/src/main/res/values/strings.xml
+++ b/Pdf417MobiDemo/pdf417MobiDemo/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">pdf417.mobi</string>
+    <string name="app_name">pdf417.watsi</string>
     <string name="UseWith">Use with</string>
     <string name="StartScanning">Start scanning</string>
 </resources>

--- a/Pdf417MobiDemo/pdf417MobiDemoCustomUI/src/main/AndroidManifest.xml
+++ b/Pdf417MobiDemo/pdf417MobiDemoCustomUI/src/main/AndroidManifest.xml
@@ -30,7 +30,6 @@
             android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
@@ -42,6 +41,10 @@
         <activity
             android:name=".DefaultScanActivity"
             android:screenOrientation="portrait" >
+            <intent-filter>
+                <action android:name="com.google.zxing.client.android.SCAN"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+            </intent-filter>
         </activity>
     </application>
 

--- a/Pdf417MobiDemo/pdf417MobiDirectAPIDemo/src/main/java/com/microblink/barcode/imagescan/ScanImageActivity.java
+++ b/Pdf417MobiDemo/pdf417MobiDirectAPIDemo/src/main/java/com/microblink/barcode/imagescan/ScanImageActivity.java
@@ -166,7 +166,7 @@ public class ScanImageActivity extends Activity {
             // disable button
             mScanButton.setEnabled(false);
             // show progress dialog
-            final ProgressDialog pd = new1 ProgressDialog(this);
+            final ProgressDialog pd = new ProgressDialog(this);
             pd.setIndeterminate(true);
             pd.setMessage("Performing recognition");
             pd.setCancelable(false);

--- a/Pdf417MobiDemo/pdf417MobiDirectAPIDemo/src/main/java/com/microblink/barcode/imagescan/ScanImageActivity.java
+++ b/Pdf417MobiDemo/pdf417MobiDirectAPIDemo/src/main/java/com/microblink/barcode/imagescan/ScanImageActivity.java
@@ -166,7 +166,7 @@ public class ScanImageActivity extends Activity {
             // disable button
             mScanButton.setEnabled(false);
             // show progress dialog
-            final ProgressDialog pd = new ProgressDialog(this);
+            final ProgressDialog pd = new1 ProgressDialog(this);
             pd.setIndeterminate(true);
             pd.setMessage("Performing recognition");
             pd.setCancelable(false);

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# _PDF417.mobi_ SDK for Android
+# _PDF417.mobi_ SDK for Android with Commcare Integration
 
 [![Build Status](https://travis-ci.org/PDF417/pdf417-android.svg?branch=master)](https://travis-ci.org/PDF417/pdf417-android)
+
+Forked from [This Repo](https://github.com/PDF417/pdf417-android)
 
 _PDF417.mobi_ SDK for Android is SDK that enables you to perform scans of various barcodes in your app. You can simply integrate the SDK into your app by following the instructions below and your app will be able to benefit the scanning feature for following barcode standards:
 


### PR DESCRIPTION
- Added an `intent-filter` with action name: `<action android:name="com.google.zxing.client.android.SCAN"/>`, which is what commcare is set to call when looking for a barcode scanner app
- main activity onCreate will automatically go into the camera, instead of having an intermediate button.
- Returns a bundle with key = `SCAN_RESULT` and value = "scanned_value"